### PR TITLE
Update doctype declaration

### DIFF
--- a/app/views/layouts/default.jade
+++ b/app/views/layouts/default.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(lang='en', xmlns='http://www.w3.org/1999/xhtml', xmlns:fb='https://www.facebook.com/2008/fbml', itemscope='itemscope', itemtype='http://schema.org/Product')
   include ../includes/head
   body


### PR DESCRIPTION
"!!! 5" for the doctype declaration is deprecated in the latest version of jade. Must now use "doctype html". 
