### PR TITLE
Update package.json npm install fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma": "~0.10.4",


### PR DESCRIPTION
Fix error :
npm ERR! peerinvalid The package karma-requirejs does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer karma@0.10.10 wants karma-requirejs@~0.2.0

On npm install
